### PR TITLE
Passing nonprofit id on upload

### DIFF
--- a/app/scripts/app/Photos.js
+++ b/app/scripts/app/Photos.js
@@ -35,14 +35,14 @@ app.factory('Photos', function($http, ezfb, api) {
           transformRequest: angular.identity
         }).success(success).error(error);
     },
-    setNonprofitProfilePhoto: function (file, success, error) {
-      $http.post(api + 'upload_nonprofit_profile_image/', file, {
+    setNonprofitProfilePhoto: function (file, nonprofit, success, error) {
+      $http.post(api + 'upload_nonprofit_profile_image/?nonprofit=' + nonprofit, file, {
         headers: {'Content-Type': undefined },
         transformRequest: angular.indenty
       }).success(success).error(error);
     },
     setNonprofitCoverPhoto: function (file, success, error) {
-      $http.post(api + 'upload_nonprofit_cover_image/', file, {
+      $http.post(api + 'upload_nonprofit_cover_image/?nonprofit=' + nonprofit, file, {
         headers: {'Content-Type': undefined },
         transformRequest: angular.indenty
       }).success(success).error(error);

--- a/app/scripts/nonprofit/NonprofitEditCtrl.js
+++ b/app/scripts/nonprofit/NonprofitEditCtrl.js
@@ -49,7 +49,7 @@ app.controller('NonprofitEditCtrl', function($scope, $http, $state, $stateParams
     if (files) {
       var fd = new FormData();
       fd.append('file', files[0]);
-      Photos.setNonprofitProfilePhoto(fd, function(response) {
+      Photos.setNonprofitProfilePhoto(fd, $scope.nonprofit.id, function(response) {
         $scope.nonprofit.image_url = response.file;
         toastr.success('Logo da ONG salva com sucesso.');
       }, function() {
@@ -61,7 +61,7 @@ app.controller('NonprofitEditCtrl', function($scope, $http, $state, $stateParams
     if (files) {
       var fd = new FormData();
       fd.append('file', files[0]);
-      Photos.setNonprofitCoverPhoto(fd, function(response) {
+      Photos.setNonprofitCoverPhoto(fd, $scope.nonprofit.id, function(response) {
         $scope.nonprofit.cover_url = response.file;
         toastr.success('Foto cover da ONG salva com sucesso.');
       }, function() {


### PR DESCRIPTION
Profile and cover image uploads now can accept nonprofit's id instead of only user owning the nonprofit.